### PR TITLE
Clean network handlers

### DIFF
--- a/forge/src/main/java/gg/chaldea/client/reset/packet/ClientReset.java
+++ b/forge/src/main/java/gg/chaldea/client/reset/packet/ClientReset.java
@@ -20,6 +20,7 @@ import net.minecraftforge.registries.GameData;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
+import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.tuple.Pair;
@@ -97,6 +98,14 @@ public class ClientReset {
 
             // Clear
             Minecraft.getInstance().clearLevel(new DirtMessageScreen(new TranslationTextComponent("connect.negotiating")));
+            try {
+                context.getNetworkManager().channel().pipeline().remove("forge:forge_fixes");
+            } catch (NoSuchElementException ignored) {
+            }
+            try {
+                context.getNetworkManager().channel().pipeline().remove("forge:vanilla_filter");
+            } catch (NoSuchElementException ignored) {
+            }
 
             // Restore
             Minecraft.getInstance().setCurrentServer(serverData);


### PR DESCRIPTION

Symptom

![bild](https://user-images.githubusercontent.com/52883522/202821695-6ac0c788-665e-4049-b42e-ad0c7c89ed9f.png)

It throws an exception because the reset packet mod dosen't clean everything
The channel handlers are still present after resetting
Problem

In handleLogin(ClientboundLoginPacket) at ClientPacketListener.java
![bild](https://user-images.githubusercontent.com/52883522/202821662-b41f8250-af8a-45c7-b2f3-93b39e74140f.png)

Everything under here doesn't even get to run.
Which may break stuff.
